### PR TITLE
15 use only one level subdomain

### DIFF
--- a/docs/infra/minio.md
+++ b/docs/infra/minio.md
@@ -83,7 +83,7 @@ helm upgrade -i minio minio/minio \
 
 Access the MinIO Console to create access keys:
 
-1. Navigate to `https://console.minio.<your-domain>/access-keys/new-account`
+1. Navigate to `https://console-minio.<your-domain>/access-keys/new-account`
 2. Log in using the **MinIO User** (`user`) and **MinIO Password** generated during the configuration step.
 3. Click **Create** to generate new access keys.
 4. Note down or download the **Access Key** and **Secret Key**.
@@ -131,7 +131,7 @@ kubectl get all -n minio
 2. **Access Dashboard:**
 
 ```
-https://console.minio.<your-domain>
+https://console-minio.<your-domain>
 ```
 
 3. **Log In**:

--- a/scripts/app-hub/values-template.yaml
+++ b/scripts/app-hub/values-template.yaml
@@ -26,9 +26,9 @@ jupyterhub:
       JUPYTERHUB_CRYPT_KEY: "${APPHUB_JUPYTERHUB_CRYPT_KEY}"
       OAUTH_CALLBACK_URL: $HTTP_SCHEME://app-hub.${INGRESS_HOST}/hub/oauth_callback
       OAUTH_LOGOUT_REDIRECT_URL: $HTTP_SCHEME://app-hub.${INGRESS_HOST}/hub/home
-      OAUTH2_USERDATA_URL: $HTTP_SCHEME://identity.keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/userinfo
-      OAUTH2_TOKEN_URL: $HTTP_SCHEME://identity.keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/token
-      OAUTH2_AUTHORIZE_URL: $HTTP_SCHEME://identity.keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/auth
+      OAUTH2_USERDATA_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/userinfo
+      OAUTH2_TOKEN_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/token
+      OAUTH2_AUTHORIZE_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/auth
       OAUTH_CLIENT_ID: application-hub
       OAUTH_CLIENT_SECRET: "${APPHUB_CLIENT_SECRET}"
 

--- a/scripts/app-hub/values-template.yaml
+++ b/scripts/app-hub/values-template.yaml
@@ -26,9 +26,9 @@ jupyterhub:
       JUPYTERHUB_CRYPT_KEY: "${APPHUB_JUPYTERHUB_CRYPT_KEY}"
       OAUTH_CALLBACK_URL: $HTTP_SCHEME://app-hub.${INGRESS_HOST}/hub/oauth_callback
       OAUTH_LOGOUT_REDIRECT_URL: $HTTP_SCHEME://app-hub.${INGRESS_HOST}/hub/home
-      OAUTH2_USERDATA_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/userinfo
-      OAUTH2_TOKEN_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/token
-      OAUTH2_AUTHORIZE_URL: $HTTP_SCHEME://identity-keycloak.${INGRESS_HOST}/realms/master/protocol/openid-connect/auth
+      OAUTH2_USERDATA_URL: $HTTP_SCHEME://auth.${INGRESS_HOST}/realms/master/protocol/openid-connect/userinfo
+      OAUTH2_TOKEN_URL: $HTTP_SCHEME://auth.${INGRESS_HOST}/realms/master/protocol/openid-connect/token
+      OAUTH2_AUTHORIZE_URL: $HTTP_SCHEME://auth.${INGRESS_HOST}/realms/master/protocol/openid-connect/auth
       OAUTH_CLIENT_ID: application-hub
       OAUTH_CLIENT_SECRET: "${APPHUB_CLIENT_SECRET}"
 

--- a/scripts/minio/apply-secrets.sh
+++ b/scripts/minio/apply-secrets.sh
@@ -1,7 +1,7 @@
 # Load utility functions
 source ../common/utils.sh
 
-echo "Access the MinIO Console to create your access key at https://console.minio.$INGRESS_HOST/access-keys/new-account"
+echo "Access the MinIO Console to create your access key at https://console-minio.$INGRESS_HOST/access-keys/new-account"
 echo "Your username is 'user' and the password is the one that was generated and outputted earlier, alteratively check the ~/.eoepca/state file for the password"
 
 ask "S3_ACCESS_KEY" "Enter the S3 Access Key" "" is_non_empty

--- a/scripts/minio/server/values-template.yaml
+++ b/scripts/minio/server/values-template.yaml
@@ -26,11 +26,11 @@ consoleIngress:
     ${CLUSTER_ISSUER_ANNOTATION}
   path: /
   hosts:
-    - console.minio.${INGRESS_HOST}
+    - console-minio.${INGRESS_HOST}
   tls:
     - secretName: minio-console-tls
       hosts:
-        - console.minio.${INGRESS_HOST}
+        - console-minio.${INGRESS_HOST}
 resources:
   requests:
     memory: 1Gi

--- a/scripts/minio/validation.sh
+++ b/scripts/minio/validation.sh
@@ -9,7 +9,7 @@ check_service_exists "minio" "minio-svc"
 check_service_exists "minio" "minio"
 
 check_url_status_code "$HTTP_SCHEME://minio.$INGRESS_HOST" "403"
-check_url_status_code "$HTTP_SCHEME://console.minio.$INGRESS_HOST" "200"
+check_url_status_code "$HTTP_SCHEME://console-minio.$INGRESS_HOST" "200"
 
 check_pvc_bound "minio" "export-minio-0"
 check_pvc_bound "minio" "export-minio-1"


### PR DESCRIPTION
It seems only the `console.minio.*` currently has a multi level subdomain. 

There is currently no identity service in the EOEPCA+ deployment guide, however, I have preemptively updated the AppHub OAuth2 environment variables to use `identity-keycloak` instead of `identity.keycloak`. 