### PR TITLE
Refactor IAM to seperate files and remove duplication

### DIFF
--- a/docs/building-blocks/iam/advanced-iam.md
+++ b/docs/building-blocks/iam/advanced-iam.md
@@ -1,0 +1,294 @@
+This document covers advanced IAM configurations beyond the basic setup. Use these steps if you want to integrate external identity providers, protect resources with fine-grained policies, and leverage roles or OPA policies for authorisation.
+
+## Integrating GitHub as an External Identity Provider
+
+Integrating GitHub as an external IdP allows your users to sign in with their GitHub accounts. You must first register an OAuth application with GitHub.
+
+### 1. Create a GitHub OAuth Application
+
+Go to the [GitHub OAuth Apps page](https://github.com/settings/applications/new) and register a new application:
+
+- **Application Name**: e.g. `EOEPCA`
+- **Homepage URL**: `https://auth-apx.<INGRESS_HOST>/realms/eoepca`
+- **Authorization Callback URL**: `https://auth-apx.<INGRESS_HOST>/realms/eoepca/broker/github/endpoint`
+
+Generate a Client Secret and note both the **Client ID** and **Client Secret**.
+
+### 2. Add GitHub to Keycloak as an Identity Provider
+
+Obtain an admin access token for Keycloak (replace `<INGRESS_HOST>` with your domain):
+
+```bash
+source ~/.eoepca/state
+ACCESS_TOKEN=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "username=${KEYCLOAK_ADMIN_USER}" \
+    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    -d "client_id=admin-cli" \
+    "https://auth-apx.${INGRESS_HOST}/realms/master/protocol/openid-connect/token" \
+  | jq -r '.access_token' \
+)
+```
+
+Set your GitHub OAuth credentials:
+
+```bash
+export GITHUB_CLIENT_ID=<your-github-client-id>
+export GITHUB_CLIENT_SECRET=<your-github-client-secret>
+```
+
+Create the GitHub identity provider in the `eoepca` realm:
+
+```bash
+curl --silent --show-error \
+  -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/identity-provider/instances" <<EOF
+{
+  "alias": "github",
+  "providerId": "github",
+  "enabled": true,
+  "config": {
+    "clientId": "${GITHUB_CLIENT_ID}",
+    "clientSecret": "${GITHUB_CLIENT_SECRET}",
+    "redirectUri": "https://auth-apx.${INGRESS_HOST}/realms/eoepca/broker/github/login"
+  }
+}
+EOF
+```
+
+Now navigate to:
+
+```
+https://auth-apx.<INGRESS_HOST>/realms/eoepca/account
+```
+
+Choose **GitHub** at the login prompt and complete the authorization flow.
+
+---
+
+## Resource Protection with Keycloak Policies
+
+This section shows how to protect endpoints by associating users, groups, and resources with Keycloak’s authorisation features. The example uses a user group (`mygroup`) and a resource (`/healthcheck`) that only group members can access.
+
+### Steps Overview
+
+1. **Create a Group** (e.g. `mygroup`).
+2. **Add a User to the Group**.
+3. **Create a Policy** that allows members of `mygroup`.
+4. **Create a Resource** to represent the endpoint (`/healthcheck`).
+5. **Create a Permission** to link the policy and resource, enforcing group-based access control.
+6. **Configure Ingress** so APISIX + Keycloak enforce these policies.
+7. **Test Access** using a Device Flow token.
+
+### Detailed Steps
+
+**Obtain Access Token for Administration:**
+
+```bash
+source ~/.eoepca/state
+ACCESS_TOKEN=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "username=${KEYCLOAK_ADMIN_USER}" \
+    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    -d "client_id=admin-cli" \
+    "https://auth-apx.${INGRESS_HOST}/realms/master/protocol/openid-connect/token" \
+  | jq -r '.access_token' \
+)
+```
+
+**Create the Group `mygroup`:**
+
+```bash
+curl --silent --show-error \
+  -X POST "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/groups" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d '{"name": "mygroup"}'
+```
+
+Retrieve the group ID:
+
+```bash
+group_id=$( \
+  curl --silent --show-error \
+    -X GET "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/groups" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  | jq -r '.[] | select(.name == "mygroup") | .id' \
+)
+echo "Group ID: ${group_id}"
+```
+
+**Add a User to the Group:**
+
+Obtain the user’s ID (e.g., the `eoepca` user created previously):
+
+```bash
+user_id=$( \
+  curl --silent --show-error \
+    -X GET "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/users?username=eoepca" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  | jq -r '.[0].id'
+)
+echo "User ID: ${user_id}"
+```
+
+Add the user to `mygroup`:
+
+```bash
+curl --silent --show-error \
+  -X PUT "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/users/${user_id}/groups/${group_id}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}"
+```
+
+**Create a Policy (`mygroup-policy`):**
+
+First, find the client ID for the client (e.g., `myclient` or another service client):
+
+```bash
+client_id=$( \
+  curl --silent --show-error \
+    -X GET "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  | jq -r '.[] | select(.clientId == "myclient") | .id' \
+)
+```
+
+Create the policy:
+
+```bash
+policy_id=$( \
+  curl --silent --show-error \
+    -X POST "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients/${client_id}/authz/resource-server/policy/group" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d @- <<EOF | jq -r '.id'
+{
+  "name": "mygroup-policy",
+  "logic": "POSITIVE",
+  "decisionStrategy": "UNANIMOUS",
+  "groups": ["${group_id}"]
+}
+EOF
+)
+echo "Policy ID: ${policy_id}"
+```
+
+**Create a Resource (`test-resource` for `/healthcheck`):**
+
+```bash
+resource_id=$( \
+  curl --silent --show-error \
+    -X POST "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients/${client_id}/authz/resource-server/resource" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d @- <<EOF | jq -r '._id'
+{
+  "name": "test-resource",
+  "uris": ["/healthcheck"],
+  "ownerManagedAccess": true
+}
+EOF
+)
+echo "Resource ID: ${resource_id}"
+```
+
+**Create a Permission (`mygroup-access`):**
+
+Link the resource and the policy.
+
+The effect of this is to allow access to anyone in the `mygroup` group to access the path `/healthcheck` within the `opa-client` service.
+
+```bash
+permission_id=$( \
+  curl --silent --show-error \
+    -X POST "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients/${client_id}/authz/resource-server/policy/resource" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -d @- <<EOF | jq -r '.id'
+{
+  "name": "mygroup-access",
+  "description": "Group mygroup access to /healthcheck",
+  "logic": "POSITIVE",
+  "decisionStrategy": "UNANIMOUS",
+  "resources": ["${resource_id}"],
+  "policies": ["${policy_id}"]
+}
+EOF
+)
+echo "Permission ID: ${permission_id}"
+```
+
+**Create Protected Ingress (APISIX Route):**
+
+Having established the protection policy in the Keycloak client `myclient` - the next step is to create an `ApisixRoute` that provides ingress to the `opa-service` endpoint exploiting `myclient` to apply the protection to incoming requests.
+
+```bash
+cat <<EOF | kubectl -n iam apply -f -
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: myservice
+spec:
+  http:
+    - name: test-resource
+      match:
+        hosts:
+          - myservice-apx.$INGRESS_HOST
+        paths:
+          - /*
+      backends:
+        - serviceName: opa-opal-client
+          servicePort: 7000
+      plugins:
+        - name: authz-keycloak
+          enable: true
+          config:
+            client_id: myclient
+            client_secret: changeme
+            discovery: "https://auth-apx.$INGRESS_HOST/realms/eoepca/.well-known/uma2-configuration"
+            ssl_verify: false
+EOF
+```
+
+Note that, for convenience, the `client_id` and `client_secret` have been included directly in the `config`. Alternatively the `secretRef` field can be used to refrence a secret that contains the `client_id` and `client_secret`.
+
+**Test Access:**
+
+Obtain a token using the device flow (see [client-management.md](client-management.md) for details), then access the protected endpoint:
+
+```bash
+curl myservice-apx.$INGRESS_HOST/healthcheck \
+  -H "Authorization: Bearer ${access_token}" \
+  -H "X-No-Force-Tls: true"
+```
+
+Group members see `{"status":"ok"}`, others see `{"error":"access_denied","error_description":"not_authorized"}`.
+
+---
+
+## Role-Based vs Group-Based Permissions
+
+The above example used a group. For more granular control or organisational alignment, you can use Keycloak roles. Instead of adding users directly to groups, you create roles and assign those roles to groups or users. Adjust the policy to reference roles instead of groups. The Keycloak Admin REST API is similar; you’d just target the `/roles` endpoints.
+
+---
+
+## OPA Policy Integration
+
+Instead of relying solely on Keycloak’s policy engine, you can use OPA policies for authorisation. Configure APISIX to query OPA for decisions:
+
+- **OPA Plugin Setup**: Instead of `authz-keycloak`, use the `opa` plugin in the ApisixRoute.
+- **OPA Policy Rego Files**: Store policies in a Git repository managed by OPAL.
+- **Policy Enforcement**: APISIX queries OPA at runtime, and OPA returns allow/deny decisions based on Rego rules.
+
+Refer to OPA documentation for writing Rego policies and OPAL docs for syncing policies from Git.
+
+

--- a/docs/building-blocks/iam/client-management.md
+++ b/docs/building-blocks/iam/client-management.md
@@ -1,0 +1,134 @@
+This document details how to manage Keycloak clients programmatically, obtain tokens, and perform device flows. Clients represent applications or services interacting with EOEPCA’s secured endpoints.
+
+## Creating a Keycloak Client
+
+**Obtain Admin Token**:
+
+```bash
+source ~/.eoepca/state
+ACCESS_TOKEN=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "username=${KEYCLOAK_ADMIN_USER}" \
+    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    -d "client_id=admin-cli" \
+    "https://auth-apx.${INGRESS_HOST}/realms/master/protocol/openid-connect/token" \
+  | jq -r '.access_token' \
+)
+```
+
+**Create a Client (`myclient`)**:
+
+```bash
+curl --silent --show-error \
+  -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients" <<EOF
+{
+  "clientId": "myclient",
+  "name": "My Client",
+  "description": "Test client created for illustration",
+  "enabled": true,
+  "protocol": "openid-connect",
+  "rootUrl": "https://myservice-apx.${INGRESS_HOST}",
+  "baseUrl": "https://myservice-apx.${INGRESS_HOST}",
+  "redirectUris": ["https://myservice-apx.${INGRESS_HOST}/*", "/*"],
+  "webOrigins": ["/*"],
+  "publicClient": false,
+  "clientAuthenticatorType": "client-secret",
+  "secret": "changeme",
+  "directAccessGrantsEnabled": false,
+  "attributes": {
+    "oauth2.device.authorization.grant.enabled": true
+  },
+  "serviceAccountsEnabled": true,
+  "authorizationServicesEnabled": true,
+  "frontchannelLogout": true
+}
+EOF
+```
+
+**Verify Creation**:
+
+```bash
+curl --silent --show-error \
+  -X GET \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients" \
+| jq '.[] | select(.clientId == "myclient")'
+```
+
+## Deleting a Client
+
+First, get the client’s unique ID:
+
+```bash
+myclient_id=$( \
+  curl --silent --show-error \
+    -X GET \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients" \
+  | jq -r '.[] | select(.clientId == "myclient") | .id' \
+)
+```
+
+Delete the client:
+
+```bash
+curl --silent --show-error \
+  -X DELETE \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/clients/${myclient_id}"
+```
+
+## Obtaining Tokens via the Device Flow
+
+The device flow is handy for CLI tools or Jupyter notebooks, where a user can log in via a browser while the tool waits for a token.
+
+**Step 1: Initiate Device Auth Flow**
+
+```bash
+source ~/.eoepca/state
+
+response=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "client_id=myclient" \
+    -d "client_secret=changeme" \
+    -d "scope=openid profile email" \
+    "https://auth-apx.${INGRESS_HOST}/realms/eoepca/protocol/openid-connect/auth/device" \
+)
+device_code=$(echo $response | jq -r '.device_code')
+verification_uri_complete=$(echo $response | jq -r '.verification_uri_complete')
+echo "Open this URL in your browser: ${verification_uri_complete}"
+```
+
+**Step 2: Authorise in Browser**
+
+Navigate to the `verification_uri_complete` URL. Log in as the required user.
+
+
+**Step 3: Poll for Token**
+
+```bash
+response=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "client_id=myclient" \
+    -d "client_secret=changeme" \
+    -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+    -d "device_code=${device_code}" \
+    "https://auth-apx.${INGRESS_HOST}/realms/eoepca/protocol/openid-connect/token" \
+)
+access_token=$(echo $response | jq -r '.access_token')
+refresh_token=$(echo $response | jq -r '.refresh_token')
+id_token=$(echo $response | jq -r '.id_token')
+```
+
+Use this `access_token` in `Authorization: Bearer` headers for requests to protected resources.

--- a/docs/building-blocks/iam/main-iam.md
+++ b/docs/building-blocks/iam/main-iam.md
@@ -1,0 +1,336 @@
+# Identity and Access Management (IAM) Deployment Guide
+
+The EOEPCA Identity and Access Management (IAM) Building Block provides secure authentication and authorisation for all platform services. It enables you to manage users, roles, policies, and integrate with external identity providers.
+
+**Key Features:**
+
+- Central user management via Keycloak
+- Fine-grained policy decisions using OPA & OPAL
+- Integration with external IdPs (e.g., GitHub)
+- Enforcement of policies at the APISIX ingress layer
+
+---
+
+## Prerequisites
+
+| Component          | Requirement                            | Documentation Link                                                |
+| ------------------ | -------------------------------------- | ----------------------------------------------------------------- |
+| Kubernetes         | Cluster (tested on v1.28)              | [Installation Guide](../infra/kubernetes-cluster-and-networking.md)             |
+| Helm               | Version 3.5 or newer                   | [Installation Guide](https://helm.sh/docs/intro/install/)         |
+| kubectl            | Configured for cluster access          | [Installation Guide](https://kubernetes.io/docs/tasks/tools/)     |
+| Ingress Controller   | Properly installed                     | [Installation Guide](../infra/ingress-controller.md)  |
+| TLS Certificates | Managed via `cert-manager` or manually | [TLS Certificate Management Guide](../infra/tls/overview.md/) |
+
+**Clone the Deployment Guide Repository:**
+
+```bash
+git clone -b 2.0-beta https://github.com/EOEPCA/deployment-guide
+cd deployment-guide/scripts/iam
+```
+
+**Check Prerequisites:**
+
+```bash
+bash check-prerequisites.sh
+```
+
+If any checks fail, address them before proceeding.
+
+---
+
+## Overview of Deployment Steps
+
+1. **Configure the IAM Environment**: Provide ingress host, storage classes, etc.
+2. **Install APISIX Ingress (if not done already)**: Ensure APISIX is ready.
+3. **Deploy Keycloak**: Set up the central identity provider.
+4. **Create the `eoepca` Realm and Basic Users**: Keep `master` for admin tasks only.
+5. **(Optional) Integrate External IdPs**: Add GitHub or other providers.
+6. **Deploy OPA & OPAL**: For advanced policy decisions.
+7. **Set up Policies & Permissions**: Restrict access to services as needed.
+8. **Test & Validate**: Confirm that IAM is working as intended.
+
+For production, use proper TLS, stable storage, and consider external identity providers. For development, simpler self-signed certs and test credentials may suffice.
+
+---
+
+## Step-by-Step Deployment
+
+### 1. Configure the IAM Deployment
+
+```bash
+bash configure-iam.sh
+```
+
+**Configuration Parameters**
+
+During the script execution, you will be prompted to provide:
+
+- **`INGRESS_HOST`**: Base domain for ingress hosts.
+    - _Example_: `example.com`
+- **`STORAGE_CLASS`**: Kubernetes storage class for persistent volumes.
+    - _Example_: `standard`
+
+The script will also generate secure passwords for:
+
+- **`KEYCLOAK_ADMIN_PASSWORD`**: Password for the Keycloak admin account.
+- **`KEYCLOAK_POSTGRES_PASSWORD`**: Password for the Keycloak PostgreSQL database.
+
+These credentials will be stored in a state file at `~/.eoepca/state`.
+
+### 2. Ensure APISIX is Installed
+
+If you haven’t installed APISIX yet, follow the [APISIX Ingress Controller Guide](https://apisix.apache.org/docs/apisix/installation-guide/).
+
+### 3. Apply Secrets
+
+```bash
+bash apply-secrets.sh
+```
+
+This creates Kubernetes secrets from the credentials generated earlier.
+
+### 4. Deploy Keycloak
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update bitnami
+helm upgrade -i keycloak bitnami/keycloak \
+  --values keycloak/generated-values.yaml \
+  --version 21.4.4 \
+  --namespace iam \
+  --create-namespace
+```
+
+Apply Keycloak ingress:
+
+```bash
+kubectl -n iam apply -f keycloak/generated-ingress.yaml
+```
+
+**Custom Keycloak Image**
+
+If you have a custom Keycloak image that includes the Keycloak-OPA adapter plugin, you can specify it in the `keycloak/values-template.yaml` file by uncommenting and modifying the `image` section:
+
+```yaml
+image:
+  registry: your.registry
+  repository: eoepca/keycloak-with-opa-plugin
+  tag: your-tag
+  pullPolicy: Always
+```
+
+Replace `your.registry`, `eoepca/keycloak-with-opa-plugin`, and `your-tag` with your registry, repository, and tag.
+
+### 5. Create the `eoepca` Realm and a Test User
+
+Instead of using `master`, create a dedicated `eoepca` realm. 
+For convenience we create an `eoepca` (test) user to support usage examples in this guide where a user must be assumed.
+
+Run:
+
+```bash
+source ~/.eoepca/state
+
+ACCESS_TOKEN=$( \
+  curl --silent --show-error \
+    -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "username=${KEYCLOAK_ADMIN_USER}" \
+    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    -d "client_id=admin-cli" \
+    "https://auth-apx.${INGRESS_HOST}/realms/master/protocol/openid-connect/token" | jq -r '.access_token' \
+)
+
+
+curl --silent --show-error \
+  -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms" <<EOF
+{
+  "realm": "eoepca",
+  "enabled": true
+}
+EOF
+
+curl --silent --show-error \
+  -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "https://auth-apx.${INGRESS_HOST}/admin/realms/eoepca/users" <<EOF
+{
+  "username": "eoepca",
+  "enabled": true,
+  "credentials": [{
+    "type": "password",
+    "value": "changeme",
+    "temporary": false
+  }]
+}
+EOF
+```
+
+Replace `"changeme"` with a secure password of your choice.
+
+
+
+### 6. (Optional) Integrate External Identity Providers
+
+If you wish to add GitHub or another IdP, see [Advanced Configuration](advanced-iam.md) for detailed instructions and examples.
+
+### 7. Create the `opa` Client
+
+Follow the steps in [Client Administration](client-management.md) to create the `opa` client in the `eoepca` realm. 
+
+You will need to: 
+
+- Update the `clientId` to `opa`.
+- Update the `rootUrl` and `baseUrl` to `opa-apx.${INGRESS_HOST}`.
+- Update the `secret` to `${OPA_CLIENT_SECRET}` which was generated in the `configure-iam.sh` script.
+
+
+### 8. Deploy OPA & OPAL
+
+```bash
+helm repo add opal https://permitio.github.io/opal-helm-chart
+helm repo update opal
+helm upgrade -i opa opal/opal \
+  --values opa/values.yaml \
+  --version 0.0.28 \
+  --namespace iam \
+  --create-namespace
+```
+
+Apply OPA ingress:
+
+```bash
+kubectl -n iam apply -f opa/generated-ingress.yaml
+```
+
+### 9. Testing & Validation
+
+```bash
+bash validation.sh
+```
+
+Check all pods:
+
+```bash
+kubectl get pods -n iam
+```
+
+Ensure all components (Keycloak, OPA, etc.) are running and accessible.
+
+---
+
+## Further Configuration & Usage
+
+For detailed steps on:
+
+- Creating and managing Keycloak clients
+- Integrating external IdPs
+- Applying advanced resource protection (groups, roles, OPA policies)
+- Using the device flow to obtain tokens in a script or notebook
+
+Refer to the [Client Administration](client-management.md) and [Advanced Configuration](advanced-iam.md).
+
+
+After deployment, the IAM exposes several endpoints for authentication, authorization, and administration. Replace `<INGRESS_HOST>` with your actual ingress host domain in the URLs below.
+
+### Keycloak
+
+**Keycloak Home Page:**
+
+- URL: `https://auth-apx.<INGRESS_HOST>/`
+
+**OpenID Connect Discovery Endpoint:**
+
+- URL: `https://auth-apx.<INGRESS_HOST>/realms/eoepca/.well-known/openid-configuration`
+
+**OAuth 2.0 Authorization Endpoint:**
+
+- URL: `https://auth-apx.<INGRESS_HOST>/realms/eoepca/protocol/openid-connect/auth`
+
+**OAuth 2.0 Token Endpoint:**
+
+- URL: `https://auth-apx.<INGRESS_HOST>/realms/eoepca/protocol/openid-connect/token`
+
+**Administration Console:**
+
+- URL: `https://auth-apx.<INGRESS_HOST>/admin/`
+
+**Accessing the Administration Console:**
+
+1. **Retrieve Admin Credentials**
+    
+    The admin credentials are stored in the state file. Retrieve them using:
+    
+    ```bash
+    source ~/.eoepca/state
+    echo "Username: $KEYCLOAK_ADMIN_USER"
+    echo "Password: $KEYCLOAK_ADMIN_PASSWORD"
+    ```
+    
+2. **Login to the Console**
+    
+    Navigate to the Administration Console URL and log in with the retrieved credentials.
+    
+
+### Open Policy Agent (OPA)
+
+**OPA Endpoint:**
+
+- URL: `https://opa-apx.<INGRESS_HOST>/`
+
+You can test policy evaluations by sending requests to OPA's REST API. For example:
+
+```bash
+curl -X POST "https://opa-apx.<INGRESS_HOST>/v1/data/example/allow" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user": "alice"}}'
+```
+
+---
+
+### Validating Kubernetes Resources
+
+Ensure that all Kubernetes resources are running correctly.
+
+```bash
+kubectl get pods -n iam
+```
+
+**Expected Output**:
+
+- All pods should be in the `Running` state.
+- No pods should be in `CrashLoopBackOff` or `Error` states.
+
+
+---
+
+## Cleanup
+
+To remove IAM components:
+
+```bash
+kubectl -n iam delete -f keycloak/generated-ingress.yaml
+bash delete-secrets.sh
+helm -n iam uninstall keycloak
+
+kubectl -n iam delete -f opa/generated-ingress.yaml
+helm -n iam uninstall opa
+```
+
+If you created custom clients or realms, remove them using the scripts in `scripts/` or the instructions in the appendices.
+
+---
+
+## Further Reading
+
+- [EOEPCA IAM Documentation](https://eoepca.readthedocs.io/projects/iam)
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Open Policy Agent Documentation](https://www.openpolicyagent.org/docs/latest/)
+- [OPAL Documentation](https://github.com/permitio/opal)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,10 @@ nav:
       - Application Deployment →: building-blocks/overview.md
   - Application Deployment:
     - Overview: building-blocks/overview.md
-    - Identity & Access (IAM): building-blocks/iam.md
+    - Identity & Access (IAM): 
+        - IAM Deployment: building-blocks/iam/main-iam.md
+        - IAM Advanced Configuration: building-blocks/iam/advanced-iam.md
+        - IAM Client Administration: building-blocks/iam/client-management.md
     - Resource Catalogue: building-blocks/resource-catalogue.md
     - Processing:
         - Overview: building-blocks/processing.md


### PR DESCRIPTION
The idea behind this was that the IAM guide was becoming a bit of a monolith. With this PR, I have made an attempt to separate the work and simplify the language.

I've kept the `iam.md` for now for reference, just in case I missed anything from doing the refactoring.